### PR TITLE
Correct margins/widths for smaller screens

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -11,13 +11,13 @@ html, body {
 }
 
 body {
-  margin: 40px;
+  margin: 10px;
 }
 
 .container {
   max-width: 600px;
   width: 100%;
-  min-width: 400px;
+  min-width: 380px;
   margin: 0 auto;
   padding: 0;
 }


### PR DESCRIPTION
The minimum width left no room for the right margin on a 400px screen, common for phones. That lead to the game not being centered and text being smushed against the right edge. This corrects that.